### PR TITLE
Version 0.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MassInstallAction"
 uuid = "e162569b-3ff4-40cf-b055-1e5f8042da73"
 authors = ["Dilum Aluthge"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"


### PR DESCRIPTION
Before merging #27 I think (since it won't be tested) that we should give it a Project.toml and commit a Manifest that locks in working versions. I want to make sure #29 is part of MassInstallAction, so we need a new registered version.