### PR TITLE
Allow custom target dirs

### DIFF
--- a/src/public.jl
+++ b/src/public.jl
@@ -83,7 +83,8 @@ function install(workflow::Workflow,
                  pr_branch_name::AbstractString = "massinstallaction/set-up-$(workflow.name)",
                  pr_title::AbstractString = "MassInstallAction: Install the $(workflow.name) workflow on this repository",
                  pr_body::AbstractString = "This pull request sets up the $(workflow.name) workflow on this repository.",
-                 commit_message::AbstractString = "Automated commit made by MassInstallAction.jl")
+                 commit_message::AbstractString = "Automated commit made by MassInstallAction.jl",
+                 target_dir::AbstractString = joinpath(".github", "workflows"))
     pkg_url_with_auth = repo.html_url.uri
     with_temp_dir() do tmp_dir
         git() do git
@@ -91,7 +92,7 @@ function install(workflow::Workflow,
             run(`$(git) clone $(pkg_url_with_auth) REPO`)
             cd("REPO")
             run(`$(git) checkout -B $(pr_branch_name)`)
-            workflows_directory = joinpath(pwd(), ".github", "workflows")
+            workflows_directory = joinpath(pwd(), target_dir)
             mkpath(workflows_directory)
             cd(workflows_directory)
             for filename in workflow.files_to_delete


### PR DESCRIPTION
It would be nice if this could be used to push all files, not just workflows, to a repo. Some tools like Dependabot or labeler require a file in `.github` or in the root dir instead.

I'm not familiar with the package, so this is untested. Feel free to push to the branch directly, too.