### PR TITLE
Remove VersionVigilante from the list of default workflows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MassInstallAction"
 uuid = "e162569b-3ff4-40cf-b055-1e5f8042da73"
 authors = ["Dilum Aluthge"]
-version = "1.0.0"
+version = "2.0.0"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Some workflows have convenient helpers:
 julia> workflow = MassInstallAction.compat_helper()      # workflow for https://github.com/JuliaRegistries/CompatHelper.jl
 
 julia> workflow = MassInstallAction.tag_bot()            # workflow for https://github.com/JuliaRegistries/TagBot
-
-julia> workflow = MassInstallAction.version_vigilante()  # workflow for https://github.com/bcbi/VersionVigilante.jl
 ```
 
 or you can create your own:

--- a/src/MassInstallAction.jl
+++ b/src/MassInstallAction.jl
@@ -5,7 +5,7 @@ Install or update GitHub Action workflows on repositories
 
 API (all require qualification with `MassInstallAction`):
 
-- Workflow creation: `Workflow`, `compat_helper`, `tag_bot`, `version_vigilante`
+- Workflow creation: `Workflow`, `compat_helper`, `tag_bot`
 - Workflow installation: `install`
 """
 module MassInstallAction

--- a/src/default_workflows.jl
+++ b/src/default_workflows.jl
@@ -15,12 +15,3 @@ function tag_bot()
     files_to_delete = Set{String}()
     return Workflow(name, files_to_create, files_to_delete)
 end
-
-function version_vigilante()
-    name = "VersionVigilante"
-    files_to_create = Dict{String, String}()
-    files_to_create["VersionVigilante_bors.yml"] = String(HTTP.get("https://raw.githubusercontent.com/bcbi/VersionVigilante.jl/master/.github/workflows/VersionVigilante_bors.yml").body)
-    files_to_create["VersionVigilante_pull_request.yml"] = String(HTTP.get("https://raw.githubusercontent.com/bcbi/VersionVigilante.jl/master/.github/workflows/VersionVigilante_pull_request.yml").body)
-    files_to_delete = Set{String}(["VersionVigilante.yml"])
-    return Workflow(name, files_to_create, files_to_delete)
-end


### PR DESCRIPTION
In hindsight, I should have done this before releasing 1.0.0 🤦 

VersionVigilante is not as popular as CompatHelper or TagBot, so I don't think it should be a default workflow.

Also, I've stopped encouraging the use of VersionVigilante.

You can obviously still use MassInstallAction.jl to install VersionVigilante by creating a custom workflow with `MassInstallAction.Workflow`. But it doesn't need to be a default.