### PR TITLE
Sleep between creating PRs to avoid rate limit

### DIFF
--- a/src/public.jl
+++ b/src/public.jl
@@ -65,6 +65,10 @@ function install(workflow::Workflow,
                                   auth = auth)
         end
         install(workflow, pkgrepo; auth=auth, pr_body=pr_body)
+
+        # Avoid GitHub secondary rate limits
+        # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
+        sleep(1)
     end
 end
 


### PR DESCRIPTION
Resolves: #40 

## Overview
Sleep between creating PRs to avoid the [secondary rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits). Tested this w/ the [Invenia organization](https://github.com/invenia/) and had no issues with rate limits.