### PR TITLE
update compat bounds of HTTP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 
 [compat]
 GitHub = "5.1.3"
-HTTP = "0.8.8"
+HTTP = "0.8.8, 0.9, 1.0"
 julia = "1.3"
 
 [extras]

--- a/src/public.jl
+++ b/src/public.jl
@@ -14,10 +14,13 @@ Submit a pull request to install `workflow` for all packages owned by `user_or_o
 
 If `pkgs` is supplied, pull requests will only be made to the listed packages.
 """
-function install(workflow::Workflow,
-                 org::AbstractString;
-                 token::Union{AbstractString, Nothing},
-                 cc::AbstractVector{<:AbstractString})
+function install(
+    workflow::Workflow,
+    org::AbstractString;
+    token::Union{AbstractString,Nothing},
+    cc::AbstractVector{<:AbstractString},
+    ignore_forks::Bool=true,
+)
     if token === nothing
         auth = nothing
     else
@@ -28,6 +31,11 @@ function install(workflow::Workflow,
     else
         orgrepos, page_data = GitHub.repos(org; auth = auth)
     end
+
+    if ignore_forks
+        orgrepos = [repo for repo in orgrepos if repo.fork == false]
+    end
+
     pkgs = Vector{String}(undef, 0)
     for r in orgrepos
         name = r.name

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,4 +21,9 @@ using Test
         @test MassInstallAction._get_repo_url_with_auth("MYORG", "MYPKG"; token = "MYTOKEN") == "https://x-access-token:MYTOKEN@github.com/MYORG/MYPKG.jl"
         @test MassInstallAction._get_repo_url_with_auth("MYORG", "MYPKG"; token = nothing) == "https://github.com/MYORG/MYPKG.jl"
     end
+
+    @testset "default workflows" begin
+        @test MassInstallAction.compat_helper() isa MassInstallAction.Workflow
+        @test MassInstallAction.tag_bot() isa MassInstallAction.Workflow
+    end
 end


### PR DESCRIPTION
I could only find uses of `HTTP.get` here, so this should be fine. See also #57